### PR TITLE
Add ATProto client integration instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # commanprompt
 GIT REPOSITORY FOR COMMANPROMPT.AI
+
+## Integrating ATProto Private Client
+
+The ATProto Private Client codebase is not included directly in this repository
+because the environment used to generate this commit does not have network
+access to download the files. To complete the integration:
+
+1. Clone the [ATPROTO-PRIVATE-CLIENT](https://github.com/MYaelMendez/ATPROTO-PRIVATE-CLIENT) repository.
+2. Copy its contents into the `atproto-client/` directory in this repository.
+
+After copying, you may commit the files or keep them as a submodule depending
+on your workflow.

--- a/atproto-client/README.md
+++ b/atproto-client/README.md
@@ -1,0 +1,8 @@
+# ATProto Private Client Integration
+
+The original code for ATProto Private Client is hosted at:
+<https://github.com/MYaelMendez/ATPROTO-PRIVATE-CLIENT>
+
+Due to environment restrictions, this repository does not include the source
+code directly. Clone the repository manually and copy its contents into this
+folder to complete the integration.


### PR DESCRIPTION
## Summary
- create `atproto-client` directory with placeholder README
- update project README with instructions for manually integrating ATProto Private Client

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_68427c216cf883278da8c33761f97431